### PR TITLE
ci: Run release check on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     name: Release Check
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/master'
+    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This allows us to configure other release trains in the semantic release bot